### PR TITLE
Show 24 hours, adjust time step for each satellite

### DIFF
--- a/store/satellites.js
+++ b/store/satellites.js
@@ -1,5 +1,15 @@
 const siteURL = 'https://satdash.wpengine.com'
 
+const getDateForApi = () => {
+  const now = new Date()
+  const hour = now.getHours()
+  if (hour < 12) {
+    return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`
+  } else {
+    return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate() + 1}`
+  }
+}
+
 export const state = () => ({
   satellites: []
 })


### PR DESCRIPTION
Adjusts time range to span +- 12hours, adjusts time increment in orbit point calculations based on initial measure of radius and velocity, and adds interpolation setting to sampledPositionProperty