### PR TITLE
Update satellite.js to consume API using date

### DIFF
--- a/store/satellites.js
+++ b/store/satellites.js
@@ -36,8 +36,6 @@ export const actions = {
    * Pulls Satellite from WordPress database and stores them in state so they can be filtered.
    */
   async getSatellites({ state, commit }) {
-    // if (state.satellites.length) return
-
     try {
       let satellites = await fetch(
         `${siteURL}/wp-json/satdash/v1/satellites?date=${state.targetDate}`

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -1,22 +1,33 @@
 const siteURL = 'https://satdash.wpengine.com'
 
-const getDateForApi = () => {
-  const now = new Date()
-  const hour = now.getHours()
+const padNumber = (num) => {
+  return num.toString().padStart(2, 0)
+}
+
+const getDateForApi = (targetDate) => {
+  const hour = targetDate.getHours()
   if (hour < 12) {
-    return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`
+    return `${padNumber(targetDate.getFullYear())}-${padNumber(
+      targetDate.getMonth() + 1
+    )}-${padNumber(targetDate.getDate())}`
   } else {
-    return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate() + 1}`
+    return `${padNumber(targetDate.getFullYear())}-${padNumber(
+      targetDate.getMonth() + 1
+    )}-${padNumber(targetDate.getDate() + 1)}`
   }
 }
 
 export const state = () => ({
-  satellites: []
+  satellites: [],
+  targetDate: getDateForApi(new Date())
 })
 
 export const mutations = {
   updateSatellites: (state, satellites) => {
     state.satellites = satellites
+  },
+  updateTargetDate: (state, newTargetDate) => {
+    state.targetDate = getDateForApi(newTargetDate)
   }
 }
 
@@ -25,11 +36,11 @@ export const actions = {
    * Pulls Satellite from WordPress database and stores them in state so they can be filtered.
    */
   async getSatellites({ state, commit }) {
-    if (state.satellites.length) return
+    // if (state.satellites.length) return
 
     try {
       let satellites = await fetch(
-        `${siteURL}/wp-json/satdash/v1/satellites`
+        `${siteURL}/wp-json/satdash/v1/satellites?date=${state.targetDate}`
       ).then((res) => res.json())
 
       commit('updateSatellites', satellites)


### PR DESCRIPTION
Satellite store is initialised with a target date set to the appropriate date for the current point in time. The Timeline component will be responsible for updating the targetDate, and triggering a new store dispatch for satellites. Please also confirm that it is safe to remove the commented out early return in getSatellites - unless I'm missing something, that would prevent any API calls being made after the first one?