### PR TITLE
Feat/visual filters

### DIFF
--- a/assets/css/abstracts/_functions.scss
+++ b/assets/css/abstracts/_functions.scss
@@ -1,3 +1,4 @@
+// @use 'variables' as *;
 @use 'sass:math';
 
 /*=================================
@@ -5,7 +6,42 @@
 =================================*/
 
 $browser-context: 16px;
+
 @function rem($size) {
+  @if is-px($size) == false {
+    $size: $size * 1px;
+  }
+
   $rem-size: $size / $browser-context;
-  @return #{$rem-size}rem;
+  @return $rem-size * 1rem;
+}
+
+@function is-number($value) {
+  @return type-of($value) == 'number';
+}
+
+@function is-px($value) {
+  @return is-number($value) and index('px', unit($value)) != null;
+}
+
+@function z-index($key) {
+  $z-index: map-get($z-index, $key);
+
+  @if $z-index {
+    @return $z-index;
+  }
+
+  @warn 'There is no item "#{$element}" in this list; choose one of: #{$list}';
+  @return null;
+}
+
+@function box-shadow($key) {
+  $box-shadow: map-get($shadows, $key);
+
+  @if $box-shadow {
+    @return $box-shadow;
+  }
+
+  @warn 'There is no item "#{$element}" in this list; choose one of: #{$list}';
+  @return null;
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,4 +1,5 @@
 // @use 'variables' as *;
+// @use 'functions' as *;
 // @use 'sass:map';
 
 /*=================================
@@ -114,4 +115,14 @@
       box-shadow: none;
     }
   }
+}
+
+// Returns the z-index given an element.
+@mixin z-index($key) {
+  z-index: z-index($key);
+}
+
+// Returns the box-shadow given a shadow-size.
+@mixin shadow($key) {
+  box-shadow: box-shadow($key);
 }

--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -77,3 +77,15 @@ $breakpoints: (
 
 $size__container-max-width: 1000px;
 $size__content-max-width: 680px;
+
+$z-index: (
+  panel: 1
+);
+
+$shadows: (
+  lg: (
+    0 10px 20px rgba(0, 0, 0, 0.64),
+    0 2px 14px rgba(0, 0, 0, 0.34),
+    0 0 1px rgba(0, 0, 0, 0.54)
+  )
+);

--- a/assets/css/components/panel.scss
+++ b/assets/css/components/panel.scss
@@ -59,5 +59,6 @@
 
   &__panel {
     height: 100%;
+    overflow: scroll;
   }
 }

--- a/assets/css/components/panel.scss
+++ b/assets/css/components/panel.scss
@@ -1,0 +1,63 @@
+.panel {
+  @include z-index(panel);
+  width: 100%;
+  // max-width: 360px;
+  padding: rem(56) rem(32px) 0;
+  color: $color-white-170;
+  background: $color-slate-600;
+  @include shadow(lg);
+}
+
+.ak-vt {
+  &__wrapper {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    @include z-index(panel);
+    width: 100%;
+    max-width: 360px;
+    @include shadow(lg);
+    transition: transform 0.3s ease-in-out;
+
+    &--no-active-tab {
+      transform: translateX(-100%);
+    }
+  }
+
+  &__list {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__activator {
+    --tab-bg: #{$color-slate-600};
+    color: $color-white-180;
+    background: var(--tab-bg, $color-slate-600);
+    border: 0;
+    border-radius: 0 4px 4px 0;
+    cursor: pointer;
+    filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.34)),
+      drop-shadow(0 2px 5px rgba(0, 0, 0, 0.24)),
+      drop-shadow(0 0 1px rgba(0, 0, 0, 0.44));
+    transition: background 0.3s ease-in-out;
+
+    &:hover {
+      --tab-bg: #{$color-slate-400};
+    }
+
+    /* stylelint-disable */
+    .ak-vt__wrapper:not(.ak-vt__wrapper--no-active-tab)
+      &[aria-selected='false'] {
+      --tab-bg: #{$color-slate-800};
+    }
+    /* stylelint-enable */
+  }
+
+  &__panel {
+    height: 100%;
+  }
+}

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -40,6 +40,10 @@ let Cesium, viewer, pathMaterial
 export default {
   props: {
     satellites: {
+      type: Object,
+      default: () => {}
+    },
+    activeSatellites: {
       type: Array,
       default: () => []
     },
@@ -65,7 +69,7 @@ export default {
     }
   },
   watch: {
-    satellites: 'processNewData'
+    activeSatellites: 'processNewData'
   },
   mounted() {
     this.$refs.vcViewer.createPromise.then(({ Cesium, viewer }) => {
@@ -143,12 +147,14 @@ export default {
 
       // For each object, calculate its position & orbit
       // Calculations pulled from: https://github.com/ut-astria/AstriaGraph/blob/master/main.js & https://github.com/ut-astria/AstriaGraph/blob/master/celemech.js
-      this.satellites.forEach((sat, i) => {
-        const { catalog_id, orbital, source1 } = sat
+      this.activeSatellites.forEach((sat, i) => {
+        const { catalog_id, orbits, source1 } = this.satellites[sat]
         const name = source1.Name
 
         // Make a copy of the orbital parameters so we can modify it with our calculations.
-        let elems = Object.assign({}, orbital)
+
+        // TODO: Change this so it looks at the correct orbit, not just the first one.
+        let elems = Object.assign({}, orbits[0].elements)
 
         // Cesium.JulianDate.fromIso8601('2020-06-13T22:00:02.000000Z', epjd)
         Cesium.JulianDate.fromIso8601(elems.Epoch, epjd)

--- a/components/visualizer/FilterTab.vue
+++ b/components/visualizer/FilterTab.vue
@@ -1,0 +1,68 @@
+<template>
+  <div>
+    <h2>{{ numFiltersApplied }} filters</h2>
+    <p v-show="numFiltersApplied == 0">
+      Please apply at least one filter to view results.
+    </p>
+    <button @click="applyFilter">Apply Filter</button>
+    <button @click="resetFilters">Reset</button>
+    {{ numSatellites }} Results<br />
+    <table border="1" borderColor="#fff" cellSpacing="0">
+      <thead>
+        <tr>
+          <td>Catalog Id</td>
+          <td>Name</td>
+        </tr>
+      </thead>
+      <tr v-for="sat in activeSatellites" :key="sat">
+        <td>{{ sat }}</td>
+        <td>{{ satellites[sat].source1.Name }}</td>
+      </tr>
+    </table>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { mapMutations } from 'vuex'
+
+export default {
+  computed: {
+    numFiltersApplied() {
+      return 0
+    },
+    // numResults() {
+    //   return this.activeSatellitesCount()
+    // },
+    satellites() {
+      return this.$store.state.satellites.satellites
+    },
+    ...mapGetters({
+      activeSatellites: 'satellites/activeSatellites',
+      numSatellites: 'satellites/activeSatellitesCount'
+    })
+  },
+  methods: {
+    applyFilter() {
+      console.log('apply the filter!')
+      let filters = {
+        countryOfLaunch: 'US'
+      }
+
+      const filteredSatellites = Object.values(this.satellites)
+        .filter((sat) => sat.source1.countryOfLaunch === 'US')
+        .map((sat) => sat.catalog_id)
+      console.log(filteredSatellites)
+      this.updateActiveSatellites(filteredSatellites)
+    },
+    resetFilters() {
+      console.log('reset filters')
+      const filteredSatellites = Object.keys(this.satellites)
+      this.updateActiveSatellites(filteredSatellites)
+    },
+    ...mapMutations({
+      updateActiveSatellites: 'satellites/updateActiveSatellites'
+    })
+  }
+}
+</script>

--- a/components/visualizer/Panel.vue
+++ b/components/visualizer/Panel.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="panel" :class="'panel--' + direction">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    direction: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import '../assets/css/components/panel';
+</style>

--- a/components/visualizer/PanelLeft.vue
+++ b/components/visualizer/PanelLeft.vue
@@ -1,0 +1,38 @@
+<template>
+  <!-- <Panel direction="left"> -->
+  <TabWrapper v-model="activeTab" orientation="vertical">
+    <TabList label="Controller">
+      <button @click="activeTab = ''">Close all</button>
+      <TabActivator tab="filters">Filters</TabActivator>
+      <TabActivator tab="list">Focus List</TabActivator>
+    </TabList>
+
+    <TabPanel tab="filters" class="panel panel--left">
+      Content for the filters goes here.
+    </TabPanel>
+    <TabPanel tab="list" class="panel panel--left">
+      The focus list goes here.
+    </TabPanel>
+  </TabWrapper>
+  <!-- </Panel> -->
+</template>
+
+<script>
+import Panel from '~/components/visualizer/Panel'
+import { TabActivator, TabList, TabPanel, TabWrapper } from '@a11y-kit/vue-tabs'
+
+export default {
+  components: {
+    // Panel,
+    TabActivator,
+    TabList,
+    TabPanel,
+    TabWrapper
+  },
+  data() {
+    return {
+      activeTab: ''
+    }
+  }
+}
+</script>

--- a/components/visualizer/PanelLeft.vue
+++ b/components/visualizer/PanelLeft.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- <Panel direction="left"> -->
   <TabWrapper v-model="activeTab" orientation="vertical">
     <TabList label="Controller">
       <button @click="activeTab = ''">Close all</button>
@@ -8,22 +7,21 @@
     </TabList>
 
     <TabPanel tab="filters" class="panel panel--left">
-      Content for the filters goes here.
+      <FilterTab />
     </TabPanel>
     <TabPanel tab="list" class="panel panel--left">
       The focus list goes here.
     </TabPanel>
   </TabWrapper>
-  <!-- </Panel> -->
 </template>
 
 <script>
-import Panel from '~/components/visualizer/Panel'
+import FilterTab from '~/components/visualizer/FilterTab'
 import { TabActivator, TabList, TabPanel, TabWrapper } from '@a11y-kit/vue-tabs'
 
 export default {
   components: {
-    // Panel,
+    FilterTab,
     TabActivator,
     TabList,
     TabPanel,
@@ -36,3 +34,7 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+@import '../assets/css/components/panel';
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@a11y-kit/utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a11y-kit/utils/-/utils-1.0.1.tgz",
+      "integrity": "sha512-uQVh5Q4J8lr1C/HbvYjVlfsKc7eeIJH09kv5KD2/jWPSMB+KpwrVH235qInlwemibZcq26pAyaMLgyfGmdityA=="
+    },
+    "@a11y-kit/vue-tabs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a11y-kit/vue-tabs/-/vue-tabs-1.0.1.tgz",
+      "integrity": "sha512-iv4S7wRp7hIp6BZE0wYm88tX1fnWQs8QVDEhq/C3NkKevFyaJbgqqS3tCxgKqyu/7G0FYIQ+/GWWqtKyp7Ax/w==",
+      "requires": {
+        "@a11y-kit/utils": "^1.0.1"
+      }
+    },
     "@amap/amap-jsapi-loader": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@amap/amap-jsapi-loader/-/amap-jsapi-loader-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "@a11y-kit/vue-tabs": "^1.0.1",
     "@nuxtjs/pwa": "^3.0.0-0",
     "axios": "^0.19.2",
     "fibers": "^4.0.2",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,11 @@
     <PanelLeft />
     <template v-if="loading"> Loading... </template>
     <template v-else>
-      <CesiumViewer :satellites="satellites" :selected-date="targetDate" />
+      <CesiumViewer
+        :satellites="satellites"
+        :active-satellites="activeSatellites"
+        :selected-date="targetDate"
+      />
 
       <Timeline :selected-date="targetDate" />
     </template>
@@ -11,6 +15,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import CesiumViewer from '~/components/visualizer/CesiumViewer'
 import PanelLeft from '~/components/visualizer/PanelLeft'
 import Timeline from '~/components/timeline/Timeline'
@@ -33,7 +38,10 @@ export default {
     },
     targetDate() {
       return this.$store.state.satellites.targetDate
-    }
+    },
+    ...mapGetters({
+      activeSatellites: 'satellites/activeSatellites'
+    })
   },
   created() {
     this.$store.dispatch('satellites/getSatellites')

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
+    <PanelLeft />
     <template v-if="loading"> Loading... </template>
-
     <template v-else>
       <CesiumViewer :satellites="satellites" :selected-date="targetDate" />
 
@@ -12,12 +12,14 @@
 
 <script>
 import CesiumViewer from '~/components/visualizer/CesiumViewer'
+import PanelLeft from '~/components/visualizer/PanelLeft'
 import Timeline from '~/components/timeline/Timeline'
 
 export default {
   layout: 'visualizer',
   components: {
     CesiumViewer,
+    PanelLeft,
     Timeline
   },
   data() {
@@ -36,6 +38,11 @@ export default {
   created() {
     this.$store.dispatch('satellites/getSatellites')
     this.loading = false
+  },
+  methods: {
+    openFilters() {
+      console.log('open filters')
+    }
   }
 }
 </script>

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -18,9 +18,19 @@ const getDateForApi = (targetDate) => {
 }
 
 export const state = () => ({
-  satellites: [],
+  satellites: {},
+  activeSatellites: [],
   targetDate: new Date()
 })
+
+export const getters = {
+  activeSatellites: (state) => {
+    return state.activeSatellites
+  },
+  activeSatellitesCount: (state, getters) => {
+    return getters.activeSatellites.length
+  }
+}
 
 export const mutations = {
   updateSatellites: (state, satellites) => {
@@ -28,6 +38,9 @@ export const mutations = {
   },
   updateTargetDate: (state, newTargetDate) => {
     state.targetDate = newTargetDate
+  },
+  updateActiveSatellites: (state, satellites) => {
+    state.activeSatellites = satellites
   }
 }
 
@@ -43,7 +56,17 @@ export const actions = {
         )}`
       ).then((res) => res.json())
 
-      commit('updateSatellites', satellites)
+      let items = {}
+      let activeItems = []
+
+      // TODO: Update API to return object keyed by ID instead of doing it here.
+      satellites.forEach((sat) => {
+        items[sat.catalog_id] = sat
+        activeItems.push(sat.catalog_id)
+      })
+
+      commit('updateSatellites', items)
+      commit('updateActiveSatellites', activeItems)
     } catch (err) {
       console.log(err)
     }


### PR DESCRIPTION
@samadd This is the first pass at creating a basic filtering system. Clicking on the "filters" button will take you to a form that lets you filter the satellites. Right now there's only two buttons: the "apply" button filters to only US satellites and the reset button.

While putting this together I realized that we needed to reorganize how the data was being stored in Vuex to make it usable (filtering on all the satellite data was super slow). I've split the data out into two properties in the satellite store: `satellites` and `activeSatellites`. `satellites` is an object that stores all of the information about the satellites, keyed by the `catalog_id`. `activeSatellites` is an array of the `catalog_id`s of all of the satellites that are active according to the filter.

To accommodate this change, I updated the Cesium Viewer to loop over the array of active satellites, and then get the necessary orbital information from there. Per my earlier change to the API so we can return multiple orbits per satellite, I also temporarily set `elems` equal to the first orbit for each satellite.

I wanted to flag this for you in a PR before I merge it in since it's a pretty substantial change. Let me know if you want to talk through anything!