### PR TITLE
Add # of filters & # of focus items to tabs

### DIFF
--- a/assets/css/components/badge.scss
+++ b/assets/css/components/badge.scss
@@ -1,0 +1,25 @@
+.badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: rem(4);
+  color: $color-white-190;
+  font-weight: bold;
+  line-height: 1;
+  letter-spacing: 0.025em;
+  background: $color-blue-100;
+  border-radius: 50%;
+
+  &--large {
+    width: rem(24);
+    height: rem(24);
+    margin: rem(8) auto;
+    @include font-size(12px);
+  }
+
+  &--small {
+    width: rem(16);
+    height: rem(16);
+    @include font-size(9px);
+  }
+}

--- a/assets/css/components/panel.scss
+++ b/assets/css/components/panel.scss
@@ -60,11 +60,12 @@
       brightness(95%) contrast(99%);
     position: relative;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     width: rem(48);
     min-height: rem(56);
     margin-bottom: rem(41);
-    padding-top: rem(16);
+    padding-top: rem(24);
     color: $color-white-180;
     background: var(--tab-bg, $color-slate-600);
     border: 0;
@@ -122,6 +123,13 @@
         brightness(94%) contrast(93%);
     }
     /* stylelint-enable */
+
+    // # of Filters Badge
+    .badge--pinned {
+      position: absolute;
+      top: rem(12);
+      left: rem(24);
+    }
   }
 
   &__panel {

--- a/components/visualizer/FilterTab.vue
+++ b/components/visualizer/FilterTab.vue
@@ -83,7 +83,7 @@
       </div>
     </div>
     <FilterResults
-      v-if="activeFilters.length > 0"
+      v-if="numActiveFilters > 0"
       :satellites="activeSatelliteMeta"
       :total-results="numSatellites"
     />
@@ -117,7 +117,6 @@ export default {
         Users: { value: 'Users', label: 'Users' },
         Status: { value: 'Status', label: 'Status' }
       },
-      activeFilters: [],
       activeFilterValues: {},
       visibleFilters: [],
       visibleFilterValues: {
@@ -135,9 +134,6 @@ export default {
     numVisibleFilters() {
       return this.visibleFilters.length
     },
-    numActiveFilters() {
-      return this.activeFilters.length
-    },
     listActiveFilters() {
       return this.activeFilters
         .map((d) => this.filterOptions[d].label)
@@ -153,7 +149,9 @@ export default {
     },
     ...mapGetters({
       activeSatellites: 'satellites/activeSatellites',
-      numSatellites: 'satellites/activeSatellitesCount'
+      numSatellites: 'satellites/activeSatellitesCount',
+      activeFilters: 'filters/activeFilters',
+      numActiveFilters: 'filters/activeFiltersCount'
     }),
     filterValueOptions() {
       let filters = {
@@ -219,7 +217,7 @@ export default {
     applyFilters() {
       console.log('apply the filter!')
       this.isEditable = false
-      this.activeFilters = [...this.visibleFilters]
+      this.updateActiveFilters([...this.visibleFilters])
       this.activeFilterValues = Object.assign({}, this.visibleFilterValues)
 
       let filters = {}
@@ -253,7 +251,7 @@ export default {
         this.visibleFilterValues[filter] = []
       }
       this.activeFilterValues = {}
-      this.activeFilters = []
+      this.updateActiveFilters([])
       this.visibleFilters = []
 
       // Reset Satellite Ids
@@ -261,7 +259,8 @@ export default {
       this.updateActiveSatellites(filteredSatellites)
     },
     ...mapMutations({
-      updateActiveSatellites: 'satellites/updateActiveSatellites'
+      updateActiveSatellites: 'satellites/updateActiveSatellites',
+      updateActiveFilters: 'filters/updateActiveFilters'
     }),
     cancelFilters() {
       console.log('cancel the filters')

--- a/components/visualizer/PanelLeft.vue
+++ b/components/visualizer/PanelLeft.vue
@@ -10,9 +10,18 @@
       </button>
       <TabActivator tab="filters">
         <Icon id="filter" class="icon" name="filter" />
+        <div
+          v-show="activeFiltersCount"
+          class="badge badge--small badge--pinned"
+        >
+          {{ activeFiltersCount }}
+        </div>
       </TabActivator>
       <TabActivator tab="list">
         <Icon id="pin" class="icon" name="pin" />
+        <div v-show="focusedSatellitesCount" class="badge badge--large">
+          {{ focusedSatellitesCount }}
+        </div>
       </TabActivator>
     </TabList>
 
@@ -26,6 +35,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import FilterTab from '~/components/visualizer/FilterTab'
 import FocusList from '~/components/visualizer/FocusList'
 import Icon from '~/components/global/Icon'
@@ -45,10 +55,17 @@ export default {
     return {
       activeTab: ''
     }
+  },
+  computed: {
+    ...mapGetters({
+      activeFiltersCount: 'filters/activeFiltersCount',
+      focusedSatellitesCount: 'satellites/focusedSatellitesCount'
+    })
   }
 }
 </script>
 
 <style lang="scss">
 @import '../assets/css/components/panel';
+@import '../assets/css/components/badge';
 </style>

--- a/store/filters.js
+++ b/store/filters.js
@@ -1,0 +1,18 @@
+export const state = () => ({
+  activeFilters: []
+})
+
+export const getters = {
+  activeFilters: (state) => {
+    return state.activeFilters
+  },
+  activeFiltersCount: (state, getters) => {
+    return getters.activeFilters.length
+  }
+}
+
+export const mutations = {
+  updateActiveFilters: (state, filters) => {
+    state.activeFilters = filters
+  }
+}


### PR DESCRIPTION
Adds badges that contain the # of filters currently applied & the # of focus items to the panel left tabs.

Adds the filters applied to the global state so it's available at the panel level.