### PR TITLE
Add teardown handlers for Timeline and CesiumViewer

### DIFF
--- a/components/timeline/Timeline.vue
+++ b/components/timeline/Timeline.vue
@@ -137,9 +137,23 @@ export default {
           viewer.clock.currentTime
         ).toLocaleDateString()
       })
+      const realDestroy = viewer.destroy
+      viewer.destroy = () => {
+        this.beforeViewerDestroy()
+        realDestroy.bind(viewer)()
+      }
     })
   },
   methods: {
+    beforeViewerDestroy() {
+      const { cesiumInstance } = cesiumService
+      const { viewer } = cesiumInstance
+      const timeline = viewer.timeline
+      viewer.container
+        .querySelector('.cesium-viewer')
+        .insertBefore(timeline.container, null)
+      cesiumService.deregisterInstance()
+    },
     selectNewDate(date) {
       this.$store.commit('satellites/updateTargetDate', date)
       this.$store.dispatch('satellites/getSatellites')

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -77,6 +77,10 @@ export default {
   watch: {
     activeSatellites: 'processNewData'
   },
+  beforeDestroy() {
+    Cesium = null
+    viewer = null
+  },
   mounted() {
     this.$refs.vcViewer.createPromise.then((cesiumInstance) => {
       cesiumService.registerInstance(cesiumInstance)

--- a/services/cesium-service.js
+++ b/services/cesium-service.js
@@ -13,6 +13,10 @@ class CesiumService {
     this.awaiters.cesium.forEach((f) => f(cesiumInstance))
   }
 
+  deregisterInstance() {
+    this.cesiumInstance = null
+  }
+
   getInstance() {
     return new Promise((resolve, reject) => {
       try {


### PR DESCRIPTION
The Cesium Viewer.destroy method tries to remove the Timeline DOM element, but as we've moved it, it's not where expected. So We have to be sneaky and wrap the viewer.destroy method and re-insert the timeline DOM element back to where it should be. We also need to deregister the cesium instance, and remove component class scope references to Cesium and the viewer in CesiumViewer when the component instances are destroyed.