### PR TITLE
Reduce path point density to improve playback performance

### DIFF
--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -212,7 +212,7 @@ export default {
             outlineWidth: 1
           },
           path: {
-            resolution: 30,
+            resolution: 2000,
             material: pathMaterial,
             width: 6,
             show: i === 0


### PR DESCRIPTION
After battling with various approaches to try and show positions and paths that were both non-janky and correct, I found a thread on the Cesium forum that pointed to the path definition as a potential area to look at. The solution to the performance issue wasn't actually explained on the thread, but I thought it worth dialling down the resolution property, and it seems to have made a big improvement to performance as far as I can see.