### PR TITLE
Refactors Satellite API

### DIFF
--- a/components/timeline/Timeline.vue
+++ b/components/timeline/Timeline.vue
@@ -98,6 +98,8 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
+import { mapMutations } from 'vuex'
 import Button from '~/components/global/Button'
 import Icon from '~/components/global/Icon'
 
@@ -223,16 +225,16 @@ export default {
     },
     selectNewDate(date) {
       console.log(date)
-      this.$store.commit('satellites/updateTargetDate', date)
-      this.$store.dispatch('satellites/getSatellites')
+      this.updateTargetDate(date)
+      this.getOrbits()
     },
     selectPlaybackSpeed(playbackSpeed) {
       const { viewer } = cesium
       viewer.clock.multiplier = playbackSpeed.value
     },
     selectTimescale(timescale) {
-      this.$store.commit('satellites/updateSelectedTimescale', timescale)
-      this.$store.dispatch('satellites/getSatellites')
+      this.updateSelectedTimescale(timescale)
+      this.getOrbits()
     },
     playOrPause() {
       if (!cesium) {
@@ -266,7 +268,14 @@ export default {
       }
 
       this.selectNewDate(newDate)
-    }
+    },
+    ...mapActions({
+      getOrbits: 'satellites/getOrbits'
+    }),
+    ...mapMutations({
+      updateSelectedTimescale: 'satellites/updateSelectedTimescale',
+      updateTargetDate: 'satellites/updateTargetDate'
+    })
   }
 }
 </script>

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -65,7 +65,7 @@ export default {
     Icon
   },
   props: {
-    satellites: {
+    satelliteOrbits: {
       type: Object,
       default: () => {}
     },
@@ -114,7 +114,8 @@ export default {
     }
   },
   watch: {
-    activeSatellites: 'processNewData'
+    // activeSatellites: 'processNewData'
+    satelliteOrbits: 'processNewData'
   },
   beforeDestroy() {
     Cesium = null
@@ -216,27 +217,29 @@ export default {
     displayObjects(Cesium, viewer) {
       let epjd = new Cesium.JulianDate()
       let CRFtoTRF = Cesium.Transforms.computeIcrfToFixedMatrix(this.SimStart)
-      let satCount = 0
       viewer.entities.removeAll()
 
       // For each object, calculate its position & orbit
       // Calculations pulled from: https://github.com/ut-astria/AstriaGraph/blob/master/main.js & https://github.com/ut-astria/AstriaGraph/blob/master/celemech.js
+
+      console.log(this.satelliteOrbits)
+
       this.activeSatellites.forEach((sat, i) => {
-        const { catalog_id, orbits, source1 } = this.satellites[sat]
+        if (!this.satelliteOrbits[sat]) {
+          return
+        }
+
+        const { catalog_id, orbits } = this.satelliteOrbits[sat]
+
         if (!orbits) {
           return
         }
-        satCount++
-        const name = source1.Name
 
-        // Make a copy of the orbital parameters so we can modify it with our calculations.
-
-        // TODO: Change this so it looks at the correct orbit, not just the first one.
         const orbit = this.compileOrbits(orbits, CRFtoTRF, epjd)
 
         viewer.entities.add({
           id: catalog_id,
-          name: `${catalog_id}: ${name}`,
+          // name: `${catalog_id}: ${name}`,
           availability: new Cesium.TimeIntervalCollection([
             new Cesium.TimeInterval({
               start: this.SimStart,

--- a/components/visualizer/FilterTab.vue
+++ b/components/visualizer/FilterTab.vue
@@ -91,6 +91,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import { mapGetters } from 'vuex'
 import { mapMutations } from 'vuex'
 import Button from '~/components/global/Button.vue'
@@ -144,9 +145,9 @@ export default {
         .filter((d) => !this.visibleFilters.includes(d))
         .map((d) => this.filterOptions[d])
     },
-    satellites() {
-      return this.$store.state.satellites.satellites
-    },
+    ...mapState({
+      satellites: (state) => state.satellites.satellites
+    }),
     ...mapGetters({
       activeSatellites: 'satellites/activeSatellites',
       numSatellites: 'satellites/activeSatellitesCount',
@@ -168,7 +169,7 @@ export default {
       const countries = [
         ...new Set(
           satellites
-            .map((d) => [d.meta.countryOfJurisdiction, d.meta.countryOfLaunch])
+            .map((d) => [d.countryOfJurisdiction, d.countryOfLaunch])
             .flat()
         )
       ]
@@ -176,12 +177,12 @@ export default {
 
       for (let i = 0; i < satellites.length; i++) {
         const sat = satellites[i]
-        filters.countryOfJurisdiction.add(sat.meta.countryOfJurisdiction)
-        filters.Purpose.add(sat.meta.Purpose)
-        filters.Users.add(sat.meta.Operator)
-        filters.Name.add(sat.meta.Name)
-        filters.NoradId.add(sat.meta.NoradId)
-        filters.Status.add(sat.meta.Status)
+        filters.countryOfJurisdiction.add(sat.countryOfJurisdiction)
+        filters.Purpose.add(sat.Purpose)
+        filters.Users.add(sat.Operator)
+        filters.Name.add(sat.Name)
+        filters.NoradId.add(sat.NoradId)
+        filters.Status.add(sat.Status)
       }
 
       for (const key in filters) {
@@ -198,7 +199,8 @@ export default {
         const catalog_id = this.activeSatellites[i]
         const { Name, Status, countryOfJurisdiction } = this.satellites[
           catalog_id
-        ].meta
+        ]
+
         results.push({
           catalog_id,
           Name,
@@ -207,6 +209,7 @@ export default {
         })
       }
 
+      console.log('activeSatelliteMeta')
       return results
     }
   },
@@ -239,10 +242,7 @@ export default {
       const filteredSatellites = Object.values(this.satellites)
         .filter(function(item) {
           for (var key in filters) {
-            if (
-              item.meta[key] !== undefined &&
-              filters[key].includes(item.meta[key])
-            )
+            if (item[key] !== undefined && filters[key].includes(item[key]))
               return true
           }
           return false

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -53,10 +53,10 @@
         v-for="item in focusedItems"
         :key="item"
         class="sat__basic sat__basic--status"
-        :data-status="satellites[item].meta.Status"
+        :data-status="satellites[item].Status"
       >
         <div class="sat__name">
-          {{ satellites[item].meta.Name }}
+          {{ satellites[item].Name }}
         </div>
         <div class="sat__id">{{ satellites[item].catalog_id }}</div>
         <div class="sat__actions">
@@ -71,7 +71,7 @@
             :id="item"
             v-model="selectedItems"
             :value="item"
-            :label="`Remove ${satellites[item].meta.Name} from focus list.`"
+            :label="`Remove ${satellites[item].Name} from focus list.`"
             :hide-label="true"
           />
         </div>

--- a/components/visualizer/details-panel/Panel.vue
+++ b/components/visualizer/details-panel/Panel.vue
@@ -84,7 +84,7 @@ export default {
   },
   computed: {
     satelliteName() {
-      return this.satellite.meta.Name
+      return this.satellite.Name
     },
     satelliteIsInFocused() {
       return this.focusedSatellites.has(this.id)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,7 @@
     <template v-if="loading"> Loading... </template>
     <template v-else>
       <CesiumViewer
-        :satellites="satellites"
+        :satellite-orbits="orbits"
         :active-satellites="activeSatellites"
         :selected-date="targetDate"
         :selected-timescale="selectedTimescale.value"
@@ -25,6 +25,8 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
+import { mapState } from 'vuex'
 import { mapGetters } from 'vuex'
 import CesiumViewer from '~/components/visualizer/CesiumViewer'
 import PanelLeft from '~/components/visualizer/PanelLeft'
@@ -47,18 +49,15 @@ export default {
     satellites() {
       return this.$store.state.satellites.satellites
     },
-    targetDate() {
-      return this.$store.state.satellites.targetDate
-    },
-    timescales() {
-      return this.$store.state.satellites.timescales
-    },
-    selectedTimescale() {
-      return this.$store.state.satellites.selectedTimescale
-    },
     detailedSatelliteInfo() {
       return this.satellites[this.detailedSatellite]
     },
+    ...mapState({
+      orbits: (state) => state.satellites.orbits,
+      targetDate: (state) => state.satellites.targetDate,
+      timescales: (state) => state.satellites.timescales,
+      selectedTimescale: (state) => state.satellites.selectedTimescale
+    }),
     ...mapGetters({
       activeSatellites: 'satellites/activeSatellites',
       detailedSatellite: 'satellites/detailedSatellite'
@@ -66,12 +65,16 @@ export default {
   },
   created() {
     this.$store.dispatch('satellites/getSatellites')
+    this.getOrbits()
     this.loading = false
   },
   methods: {
     openFilters() {
       console.log('open filters')
-    }
+    },
+    ...mapActions({
+      getOrbits: 'satellites/getOrbits'
+    })
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -50,6 +50,7 @@ export default {
       return this.satellites[this.detailedSatellite]
     },
     ...mapState({
+      satellites: (state) => state.satellites.satellites,
       orbits: (state) => state.satellites.orbits,
       targetDate: (state) => state.satellites.targetDate,
       timescales: (state) => state.satellites.timescales,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -46,9 +46,6 @@ export default {
     }
   },
   computed: {
-    satellites() {
-      return this.$store.state.satellites.satellites
-    },
     detailedSatelliteInfo() {
       return this.satellites[this.detailedSatellite]
     },
@@ -64,7 +61,6 @@ export default {
     })
   },
   created() {
-    this.$store.dispatch('satellites/getSatellites')
     this.getOrbits()
     this.loading = false
   },

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,5 @@
+export const actions = {
+  async nuxtServerInit({ dispatch }) {
+    await dispatch('satellites/getSatellites')
+  }
+}

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -90,7 +90,7 @@ export const actions = {
   async getSatellites({ state, commit }) {
     try {
       let satellites = await fetch(
-        `${siteURLLocal}/wp-json/wp/v2/satellites`
+        `${siteURLLocal}/wp-json/wp/v2/satellites?show_all=true`
       ).then((res) => res.json())
 
       let items = {}
@@ -106,8 +106,8 @@ export const actions = {
       satellites = satellites
         .filter((el) => el.status === 'publish')
         .map(({ id, ag_meta, acf }) => ({
-          PostId: id,
-          CatalogId: acf.catalog_id,
+          post_id: id,
+          catalog_id: acf.catalog_id,
           acf,
           ...ag_meta
         }))
@@ -118,8 +118,7 @@ export const actions = {
           activeItems.push(sat.acf.catalog_id)
         })
 
-      console.log('get the satellites')
-      console.log(activeItems)
+      console.log('Get the satellites.')
 
       commit('updateSatellites', Object.freeze(items))
       commit('updateActiveSatellites', activeItems)
@@ -144,15 +143,13 @@ export const actions = {
         )}&endDate=${getDateForApi(endDate)}`
       ).then((res) => res.json())
 
-      console.log(orbits)
-
       if (Array.isArray(orbits)) {
         return
       }
 
       // Todo: Modify active satellites here to trigger watch in CesiumViewer
 
-      console.log('commit')
+      console.log('Get updated orbits.')
       commit('updateOrbits', Object.freeze(orbits))
     } catch (err) {
       console.log(err)

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -1,4 +1,5 @@
 const siteURL = 'https://satdash.wpengine.com'
+const siteURLLocal = 'http://satellite-dashboard.local/'
 
 const padNumber = (num) => {
   return num.toString().padStart(2, 0)
@@ -31,14 +32,13 @@ const getDateForApi = (targetDate) => {
 
 export const state = () => ({
   satellites: {},
+  orbits: {},
   activeSatellites: [],
   focusedSatellites: new Set(),
   detailedSatellite: null,
   targetDate: new Date(new Date().setHours(0, 0, 0, 0)),
   selectedTimescale: timescales[1],
   timescales
-  // countriesOfJurisdiction: null,
-  // countriesOfLaunch: null
 })
 
 export const getters = {
@@ -63,6 +63,9 @@ export const mutations = {
   updateSatellites: (state, satellites) => {
     state.satellites = satellites
   },
+  updateOrbits: (state, orbits) => {
+    state.orbits = orbits
+  },
   updateTargetDate: (state, newTargetDate) => {
     state.targetDate = newTargetDate
   },
@@ -78,10 +81,6 @@ export const mutations = {
   updateDetailedSatellite: (state, satellite) => {
     state.detailedSatellite = satellite
   }
-  // updateCountries: (state, countries) => {
-  //   state.countriesOfJurisdiction = countries.jurisdiction
-  //   state.countriesOfLaunch = countries.launch
-  // }
 }
 
 export const actions = {
@@ -126,6 +125,41 @@ export const actions = {
       commit('updateSatellites', items)
       commit('updateActiveSatellites', activeItems)
       // commit('updateCountries', countries)
+    } catch (err) {
+      console.log(err)
+    }
+  },
+
+  /**
+   * Pulls Satellite Orbit Information from WordPress database. Pulls based on given date range.
+   */
+  async getOrbits({ state, commit }) {
+    try {
+      const endDate = new Date(state.targetDate)
+      endDate.setSeconds(
+        endDate.getSeconds() + state.selectedTimescale.value - 1
+      ) // minus 1 second so we don't get n + 1 days
+
+      // let orbits = await fetch(
+      //   `${siteURLLocal}/wp-json/satdash/v1/satellites/orbits/?startDate=${getDateForApi(
+      //     state.targetDate
+      //   )}&endDate=${getDateForApi(endDate)}`
+      // ).then((res) => res.json())
+
+      let orbits = await fetch(
+        `${siteURLLocal}/wp-json/satdash/v1/satellites/orbits/?startDate=${getDateForApi(
+          state.targetDate
+        )}&endDate=${getDateForApi(endDate)}`
+      ).then((res) => res.json())
+
+      console.log(orbits)
+
+      if (Array.isArray(orbits)) {
+        return
+      }
+
+      console.log('commit')
+      commit('updateOrbits', orbits)
     } catch (err) {
       console.log(err)
     }

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -90,7 +90,7 @@ export const actions = {
   async getSatellites({ state, commit }) {
     try {
       let satellites = await fetch(
-        `${siteURLLocal}/wp-json/wp/v2/satellites?show_all=true`
+        `${siteURL}/wp-json/wp/v2/satellites?show_all=true`
       ).then((res) => res.json())
 
       let items = {}
@@ -138,7 +138,7 @@ export const actions = {
       ) // minus 1 second so we don't get n + 1 days
 
       let orbits = await fetch(
-        `${siteURLLocal}/wp-json/satdash/v1/satellites/orbits/?startDate=${getDateForApi(
+        `${siteURL}/wp-json/satdash/v1/satellites/orbits/?startDate=${getDateForApi(
           state.targetDate
         )}&endDate=${getDateForApi(endDate)}`
       ).then((res) => res.json())

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -119,8 +119,9 @@ export const actions = {
         })
 
       console.log('get the satellites')
+      console.log(activeItems)
 
-      commit('updateSatellites', items)
+      commit('updateSatellites', Object.freeze(items))
       commit('updateActiveSatellites', activeItems)
     } catch (err) {
       console.log(err)
@@ -152,7 +153,7 @@ export const actions = {
       // Todo: Modify active satellites here to trigger watch in CesiumViewer
 
       console.log('commit')
-      commit('updateOrbits', orbits)
+      commit('updateOrbits', Object.freeze(orbits))
     } catch (err) {
       console.log(err)
     }


### PR DESCRIPTION
@samadd Tagging you for awareness of this change. I think I fixed all of the references, but wanted to let you know that this happened.

Refactors the satellite API to work with the new endpoints that split the satellite meta information from the orbital information. The meta information is now loaded in once on start up & is available globally throughout the site. The orbital information is pulled in on the initial page load, and then updated when the user changes the timeline.

Note to self: I changed the Cesium Viewer to watch for the orbits to change instead of the active satellites - I still need to work out that relationship so it's more consistent. That is next on my to do list.