### PR TITLE
Zoom to and track selected entity, fix end of path

### DIFF
--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -422,7 +422,7 @@ export default {
       )
       positionSamples.setInterpolationOptions({
         interpolationAlgorithm: Cesium.LagrangePolynomialApproximation,
-        interpolationDegree: 1
+        interpolationDegree: 2
       })
 
       const duration = this.SimInt

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -171,10 +171,22 @@ export default {
         })
 
         if (!entity) {
+          viewer.trackedEntity = undefined
           return
         }
 
         entity.path.show = true
+        viewer.trackedEntity = entity
+        const entityPosition = viewer.scene.mapProjection.ellipsoid.cartesianToCartographic(
+          entity.position.getValue(viewer.clock.currentTime)
+        )
+        entityPosition.height = entityPosition.height + this.defaultZoomAmount
+        const cameraPosition = viewer.scene.mapProjection.ellipsoid.cartographicToCartesian(
+          entityPosition
+        )
+        viewer.camera.flyTo({
+          destination: cameraPosition
+        })
         this.showSatelliteDetails(entity.id)
       })
 
@@ -182,7 +194,7 @@ export default {
       so that it does not track the Earth's rotation, and we see the
       Earth rotating from a fixed position */
       viewer.scene.postUpdate.addEventListener((scene, time) => {
-        if (scene.mode !== Cesium.SceneMode.SCENE3D) {
+        if (viewer.trackedEntity || scene.mode !== Cesium.SceneMode.SCENE3D) {
           return
         }
         const icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(time)
@@ -276,7 +288,7 @@ export default {
               start: this.SimStart,
               stop: Cesium.JulianDate.addSeconds(
                 this.SimStop,
-                this.SimInt * 0.01, // add 1% to ensure satellites don't disappear when Cesium goes slightly beyond
+                this.SimInt * 0.1, // add 10% to ensure satellites don't disappear when Cesium goes slightly beyond
                 new Cesium.JulianDate()
               )
             })
@@ -287,7 +299,7 @@ export default {
             color: entityColors[status].point
           },
           path: {
-            resolution: 2000,
+            resolution: 400,
             material: entityColors[status].path,
             width: 4,
             show: false
@@ -423,6 +435,7 @@ export default {
       calculations are evenly spaced */
       const paddedOrbits = []
       let lastMatch = 0
+      let finalElement
       for (let day = 0; day < numDays; day++) {
         const targetDate = Cesium.JulianDate.toDate(
           Cesium.JulianDate.addDays(this.SimStart, day, new Cesium.JulianDate())
@@ -433,10 +446,14 @@ export default {
           lastMatch++
         }
         paddedOrbits.push(orbit)
+        finalElement = orbit
       }
 
       const orbitalFragmentSize = duration / paddedOrbits.length
       let step = (duration / 360) * 1000
+
+      //tack on an extra one so visibility doesn't cut off
+      paddedOrbits.push(finalElement)
 
       paddedOrbits.forEach((orbit, i, a) => {
         const elems = Object.assign({}, orbit.elements)
@@ -445,10 +462,9 @@ export default {
           orbitalFragmentSize * i,
           new Cesium.JulianDate()
         )
-        const padFactor = i === a.length - 1 ? 1.01 : 1
         const fragmentEnd = Cesium.JulianDate.addSeconds(
           this.SimStart,
-          orbitalFragmentSize * (i + 1) * padFactor,
+          orbitalFragmentSize * (i + 1),
           new Cesium.JulianDate()
         )
 

--- a/components/visualizer/FilterResults.vue
+++ b/components/visualizer/FilterResults.vue
@@ -160,12 +160,12 @@ export default {
 
       if (viewer.selectedEntity == entity || viewer.trackedEntity == entity) {
         viewer.selectedEntity = null
-        viewer.trackedEntity = null
+        //viewer.trackedEntity = null
         return
       }
 
       viewer.selectedEntity = entity
-      viewer.trackedEntity = entity
+      //viewer.trackedEntity = entity
     },
     checkItemFocusedState(catalog_id) {
       return this.focusedItems.has(catalog_id)

--- a/components/visualizer/details-panel/Panel.vue
+++ b/components/visualizer/details-panel/Panel.vue
@@ -117,13 +117,13 @@ export default {
 
       if (viewer.selectedEntity == entity || viewer.trackedEntity == entity) {
         viewer.selectedEntity = undefined
-        viewer.trackedEntity = undefined
+        //viewer.trackedEntity = undefined
         entity.path.show = false
         return
       }
 
       viewer.selectedEntity = entity
-      viewer.trackedEntity = entity
+      //viewer.trackedEntity = entity
     },
     toggleFocusState() {
       let newFocusedItems = new Set(this.focusedSatellites)


### PR DESCRIPTION
Set tracked entity on viewer.selectedEntityChanged event - this negates the need to set tracked entity in the panel control events, however I've just commented those out for now, in case you want to distinguish between selecting and tracking an entity (in terms of the Cesium Viewer). Selected is when the green tracker is over the entity, tracked is when the camera follows the entity.
Also fixes the wonky straight line on the paths by just adding a full extra cycle on to the orbit calculations.
I've increased the path resolution a bit, to benefit the view at close zoom levels. 