### PR TITLE
Feat/specify satellites time query string

### DIFF
--- a/components/global/Navigation.vue
+++ b/components/global/Navigation.vue
@@ -11,9 +11,22 @@
         <nuxt-link :to="item.url">{{ item.title }}</nuxt-link>
       </li>
       <li>
-        <nuxt-link :to="'?satids=41543,28629&date=2021-03-02&time=13'">
+        <nuxt-link
+          :to="'?satids=41543,28629&date=2021-03-02&time=43200&timescale=day'"
+        >
           Test Q string
         </nuxt-link>
+      </li>
+      <li>
+        <nuxt-link
+          :to="
+            '?satids=11570,21052,16667&date=2021-02-28&time=86400&timescale=week'
+          "
+        >
+          Test Q string
+        </nuxt-link>
+      </li>
+      <li>
         <nuxt-link :to="'/'"> clear Q string </nuxt-link>
       </li>
     </ul>

--- a/components/global/Navigation.vue
+++ b/components/global/Navigation.vue
@@ -10,25 +10,6 @@
       >
         <nuxt-link :to="item.url">{{ item.title }}</nuxt-link>
       </li>
-      <li>
-        <nuxt-link
-          :to="'?satids=41543,28629&date=2021-03-02&time=43200&timescale=day'"
-        >
-          Test Q string
-        </nuxt-link>
-      </li>
-      <li>
-        <nuxt-link
-          :to="
-            '?satids=11570,21052,16667&date=2021-02-28&time=86400&timescale=week'
-          "
-        >
-          Test Q string
-        </nuxt-link>
-      </li>
-      <li>
-        <nuxt-link :to="'/'"> clear Q string </nuxt-link>
-      </li>
     </ul>
   </div>
 </template>

--- a/components/global/Navigation.vue
+++ b/components/global/Navigation.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="nav" :class="parentClass">
-    <h2 v-if="parentClass == 'nav--footer'">
-      Navigate
-    </h2>
+    <h2 v-if="parentClass == 'nav--footer'">Navigate</h2>
     <ul class="nav__list" role="list">
       <li
         v-for="item in items"
@@ -11,6 +9,12 @@
         class="nav__item"
       >
         <nuxt-link :to="item.url">{{ item.title }}</nuxt-link>
+      </li>
+      <li>
+        <nuxt-link :to="'?satids=41543,28629&date=2021-03-02&time=13'">
+          Test Q string
+        </nuxt-link>
+        <nuxt-link :to="'/'"> clear Q string </nuxt-link>
       </li>
     </ul>
   </div>

--- a/components/timeline/Timeline.vue
+++ b/components/timeline/Timeline.vue
@@ -170,6 +170,12 @@ export default {
       return this.timelinePoint.toLocaleDateString('en-US', this.dateOptions)
     }
   },
+  watch: {
+    '$route.query.date': 'handleDateQuery'
+  },
+  created() {
+    //this.handleDateQuery()
+  },
   mounted() {
     cesiumService.getInstance().then((cesiumInstance) => {
       cesium = cesiumInstance
@@ -219,6 +225,17 @@ export default {
     })
   },
   methods: {
+    handleDateQuery() {
+      const { date } = this.$route.query
+      if (!date) {
+        return
+      }
+      const selectedDate = new Date(date)
+      if (isNaN(selectedDate.valueOf())) {
+        return
+      }
+      this.selectNewDate(selectedDate)
+    },
     beforeViewerDestroy() {
       const { cesiumInstance } = cesiumService
       const { viewer } = cesiumInstance
@@ -230,6 +247,9 @@ export default {
     },
     stopPlayback() {
       this.isPlaying = false
+      if (!cesium) {
+        return
+      }
       const { viewer } = cesium
       viewer.clockViewModel.shouldAnimate = false
     },

--- a/components/timeline/Timeline.vue
+++ b/components/timeline/Timeline.vue
@@ -173,9 +173,6 @@ export default {
   watch: {
     '$route.query.date': 'handleDateQuery'
   },
-  created() {
-    //this.handleDateQuery()
-  },
   mounted() {
     cesiumService.getInstance().then((cesiumInstance) => {
       cesium = cesiumInstance
@@ -226,7 +223,7 @@ export default {
   },
   methods: {
     handleDateQuery() {
-      const { date } = this.$route.query
+      const { date, timescale } = this.$route.query
       if (!date) {
         return
       }
@@ -234,7 +231,13 @@ export default {
       if (isNaN(selectedDate.valueOf())) {
         return
       }
-      this.selectNewDate(selectedDate)
+      const selectedTimescale = this.timescales.find((t) => t.id === timescale)
+      if (!selectedTimescale) {
+        this.selectNewDate(selectedDate)
+        return
+      }
+      this.chosenTimescale = timescale
+      this.selectNewDateAndTimescale(selectedDate, selectedTimescale)
     },
     beforeViewerDestroy() {
       const { cesiumInstance } = cesiumService
@@ -252,6 +255,12 @@ export default {
       }
       const { viewer } = cesium
       viewer.clockViewModel.shouldAnimate = false
+    },
+    selectNewDateAndTimescale(date, timescale) {
+      this.stopPlayback()
+      this.updateSelectedTimescale(timescale)
+      this.updateTargetDate(date)
+      this.getOrbits()
     },
     selectNewDate(date) {
       this.stopPlayback()

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -146,9 +146,9 @@ export default {
         return
       }
       if (this.$route.query.time) {
-        const seconds = parseInt(this.$route.query.time)
+        let seconds = parseInt(this.$route.query.time)
         if (isNaN(seconds)) {
-          viewer.clock.currentTime = this.SimStart
+          seconds = 0
         }
         viewer.clock.currentTime = Cesium.JulianDate.addSeconds(
           this.SimStart,

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -146,10 +146,13 @@ export default {
         return
       }
       if (this.$route.query.time) {
-        const hours = parseFloat(this.$route.query.time)
+        const seconds = parseInt(this.$route.query.time)
+        if (isNaN(seconds)) {
+          viewer.clock.currentTime = this.SimStart
+        }
         viewer.clock.currentTime = Cesium.JulianDate.addSeconds(
           this.SimStart,
-          hours * 60 * 60,
+          seconds,
           new Cesium.JulianDate()
         )
       } else {
@@ -266,17 +269,6 @@ export default {
         timeline.zoomTo(this.SimStart, this.SimStop)
       })
       this.handleTimeQuery()
-      //viewer.clock.currentTime = this.SimStart
-      /*if (this.$route.query.time) {
-        const hours = parseFloat(this.$route.query.time)
-        viewer.clock.currentTime = Cesium.JulianDate.addSeconds(
-          this.SimStart,
-          hours * 60 * 60,
-          new Cesium.JulianDate()
-        )
-      } else {
-        viewer.clock.currentTime = this.SimStart
-      }*/
       // Set up the current time and then load in the satellite objects.
       Cesium.Transforms.preloadIcrfFixed(
         new Cesium.TimeInterval({
@@ -545,10 +537,17 @@ export default {
       }
     },
     toggleObjectVisibility() {
+      if (!viewer) {
+        return
+      }
       const entities = viewer.entities.values
       entities.forEach((entity) => {
         entity.show = this.visibleSatellites.includes(entity.id)
       })
+      if (this.visibleSatellites.length > entities.length) {
+        // we need to restore the lost entities
+        this.displayObjects(Cesium, viewer)
+      }
     },
     toggleSunlight() {
       this.showSunlight = !this.showSunlight

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -109,6 +109,9 @@ export default {
       hideObjectLabels: false
     }
   },
+  mounted() {
+    this.handleQueryString()
+  },
   computed: {
     focusedItems() {
       return new Set(this.focusedSatellites)
@@ -152,7 +155,7 @@ export default {
       this.updateVisibleSatellites(visibleSatellites)
       /*}*/
     },
-    '$route.query': 'handleQueryString'
+    '$route.query.satids': 'handleQueryString'
   },
   methods: {
     editFocusList() {

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -109,9 +109,6 @@ export default {
       hideObjectLabels: false
     }
   },
-  mounted() {
-    this.handleQueryString()
-  },
   computed: {
     focusedItems() {
       return new Set(this.focusedSatellites)
@@ -156,6 +153,9 @@ export default {
       /*}*/
     },
     '$route.query.satids': 'handleQueryString'
+  },
+  mounted() {
+    this.handleQueryString()
   },
   methods: {
     editFocusList() {

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -144,10 +144,15 @@ export default {
       console.log('show everything')
     },
     focusedItems: function(val, oldVal) {
-      if (this.isOpen) {
-        this.updateVisibleSatellites([...this.focusedSatellites])
-      }
-    }
+      /*if (this.isOpen) {*/
+      const visibleSatellites =
+        this.focusedSatellites.size > 0
+          ? [...this.focusedSatellites]
+          : Object.keys(this.$store.state.satellites.satellites)
+      this.updateVisibleSatellites(visibleSatellites)
+      /*}*/
+    },
+    '$route.query': 'handleQueryString'
   },
   methods: {
     editFocusList() {
@@ -156,6 +161,12 @@ export default {
     cancelEditing() {
       this.isEditable = false
       this.selectedItems = []
+    },
+    handleQueryString() {
+      const satIds = this.$route.query.satids
+        ? new Set(this.$route.query.satids.split(','))
+        : new Set([])
+      this.updateFocusedSatellites(satIds)
     },
     removeFromFocused() {
       let newFocusedItems = new Set(this.focusedSatellites)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,7 +61,11 @@ export default {
     })
   },
   created() {
-    this.getOrbits()
+    if (this.$route.query.date) {
+      this.getOrbits({ date: this.$route.query.date })
+    } else {
+      this.getOrbits()
+    }
     this.loading = false
   },
   methods: {

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -15,14 +15,17 @@ const oneMonth = oneWeek * 4
 
 const timescales = [
   {
+    id: 'day',
     label: 'Day',
     value: oneDay
   },
   {
+    id: 'week',
     label: 'Week',
     value: oneWeek
   },
   {
+    id: 'month',
     label: 'Month',
     value: oneMonth
   }
@@ -237,7 +240,11 @@ export const actions = {
   /**
    * Pulls Satellite Orbit Information from WordPress database. Pulls based on given date range.
    */
-  async getOrbits({ state, commit }) {
+  async getOrbits({ state, commit }, payload) {
+    if (payload && payload.date) {
+      const date = new Date(payload.date)
+      commit('updateTargetDate', date)
+    }
     try {
       const endDate = new Date(state.targetDate)
       endDate.setSeconds(


### PR DESCRIPTION
Accepts values for satids (comma-separated id list), date (YYYY-mm-dd), time (seconds after midnight on the selected date) and timescale ('day', 'week', 'month')
Also in Cesium Viewer, re-create entities when "de-focusing", otherwise they don't exist and can't be re-shown.