### PR TITLE
Add tooltips to Entities

### DIFF
--- a/assets/css/pages/visualizer.scss
+++ b/assets/css/pages/visualizer.scss
@@ -88,3 +88,13 @@
     }
   }
 }
+
+.cesium-viewer-selectionIndicatorContainer .cesium-selection-wrapper {
+  width: unset;
+  height: unset;
+  padding: rem(8);
+  @extend %font-ui-text-sm-oxygen;
+  color: $color-white-160;
+  background: $color-slate-695;
+  @include shadow('xsm');
+}

--- a/assets/css/pages/visualizer.scss
+++ b/assets/css/pages/visualizer.scss
@@ -89,9 +89,8 @@
   }
 }
 
-.cesium-viewer-selectionIndicatorContainer .cesium-selection-wrapper {
-  width: unset;
-  height: unset;
+.cesium__entity-label {
+  position: absolute;
   padding: rem(8);
   @extend %font-ui-text-sm-oxygen;
   color: $color-white-160;

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -101,7 +101,7 @@ export default {
       SimStop: null,
       showSunlight: true,
       satellitesHaveLoaded: false,
-      selectionIndicator: false,
+      selectionIndicator: true,
       defaultZoomAmount: 15000000,
       defaultPosition: {
         lng: -80,
@@ -180,7 +180,9 @@ export default {
           return
         }
 
-        entity.label.show = true
+        // Update selection indicator to show entity name.
+        viewer.selectionIndicator.viewModel.selectionIndicatorElement.innerHTML = `${entity.name}`
+
         entity.path.show = true
         viewer.trackedEntity = entity
         const entityPosition = viewer.scene.mapProjection.ellipsoid.cartesianToCartographic(
@@ -289,7 +291,7 @@ export default {
 
         viewer.entities.add({
           id: catalog_id,
-          // name: `${catalog_id}: ${name}`,
+          name: Name,
           availability: new Cesium.TimeIntervalCollection([
             new Cesium.TimeInterval({
               start: this.SimStart,
@@ -310,21 +312,6 @@ export default {
             material: entityColors[Status].path,
             width: 4,
             show: false
-          },
-          label: {
-            id: catalog_id,
-            text: Name,
-            font: '12px sans-serif',
-            fillColor: new Cesium.Color(1, 1, 1, 0.6),
-            backgroundColor: new Cesium.Color.fromCssColorString(
-              'rgba(22, 25, 28, 0.95)'
-            ),
-            backgroundPadding: new Cesium.Cartesian2(8, 8),
-            showBackground: true,
-            show: false,
-            horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
-            verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-            pixelOffset: new Cesium.Cartesian2(4, -8)
           }
         })
       })

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -280,7 +280,7 @@ export default {
 
         const orbit = this.compileOrbits(orbits, epjd)
 
-        const status = this.satellites[catalog_id].Status
+        const { Name, Status } = this.satellites[catalog_id]
 
         viewer.entities.add({
           id: catalog_id,
@@ -298,13 +298,28 @@ export default {
           position: orbit,
           point: {
             pixelSize: 6,
-            color: entityColors[status].point
+            color: entityColors[Status].point
           },
           path: {
             resolution: 400,
-            material: entityColors[status].path,
+            material: entityColors[Status].path,
             width: 4,
             show: false
+          },
+          label: {
+            id: catalog_id,
+            text: Name,
+            font: '12px sans-serif',
+            fillColor: new Cesium.Color(1, 1, 1, 0.6),
+            backgroundColor: new Cesium.Color.fromCssColorString(
+              'rgba(22, 25, 28, 0.95)'
+            ),
+            backgroundPadding: new Cesium.Cartesian2(8, 8),
+            showBackground: true,
+            show: false,
+            horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
+            verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+            pixelOffset: new Cesium.Cartesian2(4, -8)
           }
         })
       })

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -176,6 +176,7 @@ export default {
 
         if (!entity) {
           viewer.trackedEntity = undefined
+          this.zoomReset()
           return
         }
 

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -25,6 +25,7 @@
       :fullscreen-button="fullscreenButton"
       :info-box="infoBox"
       :camera="camera"
+      :selection-indicator="selectionIndicator"
       @ready="ready"
     >
       <!-- <vc-layer-imagery
@@ -100,6 +101,7 @@ export default {
       SimStop: null,
       showSunlight: true,
       satellitesHaveLoaded: false,
+      selectionIndicator: false,
       defaultZoomAmount: 15000000,
       defaultPosition: {
         lng: -80,
@@ -169,6 +171,7 @@ export default {
         const entities = viewer.entities.values
         entities.forEach((e) => {
           e.path.show = false
+          e.label.show = false
         })
 
         if (!entity) {
@@ -176,6 +179,7 @@ export default {
           return
         }
 
+        entity.label.show = true
         entity.path.show = true
         viewer.trackedEntity = entity
         const entityPosition = viewer.scene.mapProjection.ellipsoid.cartesianToCartographic(

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -9,13 +9,6 @@
     <ul class="focus-list__options" role="list">
       <li>
         <Toggle
-          id="hide_unlisted"
-          v-model="hideUnlisted"
-          label="Hide unlisted objects"
-        />
-      </li>
-      <li>
-        <Toggle
           id="hide_object_labels"
           v-model="hideObjectLabels"
           label="Hide object labels"
@@ -127,14 +120,6 @@ export default {
     })
   },
   watch: {
-    hideUnlisted: function(val, oldVal) {
-      if (val) {
-        console.log('hide anything not in the focus list')
-        return
-      }
-
-      console.log('show everything')
-    },
     hideObjectLabels: function(val, oldVal) {
       if (val) {
         console.log('hide anything not in the focus list')


### PR DESCRIPTION
**Still a WIP**

The default "label" for Cesium entities do not render well - they're very blurry. I had [originally updated](https://community.cesium.com/t/clean-text-labels-with-cesium/12617) the selectionIndicator HTML to show the name of the entity, but since we want to be able to show more than one path at a time, I opted for a solution that would add an HTML element to hold each label.

Sam, I was hoping you could take a look at the code in CesiumViewer.vue and let me know what you think? Everything functions the way that it should, but I'm a bit concerned that it's not particularly performant, so I'm interested in your thoughts. I wasn't sure if the position calculations should happen in the `viwer.scene.postUpdate` section as opposed to where I've put them.
