### PR TITLE
Bug/camera jump on selection change

### DIFF
--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -212,6 +212,10 @@ export default {
             label = document.getElementById(`entity-${entity.id}`)
           }
 
+          if (!label) {
+            return
+          }
+
           // Moving entities don't have a position for every possible time, need to check.
           if (position3d) {
             position2d = Cesium.SceneTransforms.wgs84ToWindowCoordinates(
@@ -246,15 +250,13 @@ export default {
           const entity = Cesium.defaultValue(picked.id, picked.primitive.id)
           if (entity instanceof Cesium.Entity) {
             if (highlightedEntities.has(entity)) {
-              viewer.selectedEntity = null
               highlightedEntities.delete(entity)
-              if (highlightedEntities.size === 0) {
-                this.zoomReset()
-              }
               entity.path.show = false
               document.getElementById(`entity-${entity.id}`).remove()
+              viewer.selectedEntity = null
             } else {
               // Update highlightedEntries & add label when the selectedEntity changes to make behavior consistent across viewer & buttons on panels.
+              highlightedEntities.add(entity)
               viewer.selectedEntity = entity
             }
           }
@@ -270,8 +272,10 @@ export default {
 
       viewer.selectedEntityChanged.addEventListener((entity) => {
         if (!entity) {
-          this.zoomReset()
-          viewer.trackedEntity = null
+          if (highlightedEntities.size === 0 || entity === false) {
+            this.zoomReset()
+            viewer.trackedEntity = null
+          }
           return
         }
 

--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -240,16 +240,17 @@ export default {
       })
 
       // Toggle an entity's path & label if we click on it.
-      function selectEntity(event) {
+      const selectEntity = (event) => {
         const picked = viewer.scene.pick(event.position)
         if (Cesium.defined(picked)) {
           const entity = Cesium.defaultValue(picked.id, picked.primitive.id)
           if (entity instanceof Cesium.Entity) {
             if (highlightedEntities.has(entity)) {
-              viewer.selectedEntity = false
-              viewer.trackedEntity = false
-
+              viewer.selectedEntity = null
               highlightedEntities.delete(entity)
+              if (highlightedEntities.size === 0) {
+                this.zoomReset()
+              }
               entity.path.show = false
               document.getElementById(`entity-${entity.id}`).remove()
             } else {
@@ -257,6 +258,8 @@ export default {
               viewer.selectedEntity = entity
             }
           }
+        } else if (highlightedEntities.size === 0) {
+          this.zoomReset()
         }
       }
 
@@ -267,6 +270,8 @@ export default {
 
       viewer.selectedEntityChanged.addEventListener((entity) => {
         if (!entity) {
+          this.zoomReset()
+          viewer.trackedEntity = null
           return
         }
 
@@ -283,6 +288,7 @@ export default {
           entity.position.getValue(viewer.clock.currentTime)
         )
         entityPosition.height = entityPosition.height + this.defaultZoomAmount
+
         const cameraPosition = viewer.scene.mapProjection.ellipsoid.cartographicToCartesian(
           entityPosition
         )
@@ -611,12 +617,12 @@ export default {
         })
       }
 
-      if (Cesium.defined(viewer.trackedEntity)) {
+      /*if (Cesium.defined(viewer.trackedEntity)) {
         // when tracking do not reset to default view but to default view of tracked entity
         // const trackedEntity = viewer.trackedEntity
-        viewer.trackedEntity = undefined
+        //viewer.trackedEntity = undefined
         // viewer.trackedEntity = trackedEntity
-      }
+      }*/
     },
     toggleObjectVisibility() {
       if (!viewer) {

--- a/components/visualizer/details-panel/Panel.vue
+++ b/components/visualizer/details-panel/Panel.vue
@@ -136,11 +136,13 @@ export default {
       }
 
       if (viewer.trackedEntity == entity) {
-        viewer.trackedEntity = false
+        viewer.trackedEntity = null
+        viewer.selectedEntity = null
         this.isTracked = false
         return
       }
       viewer.trackedEntity = entity
+      viewer.selectedEntity = entity
       this.isTracked = true
     },
     toggleFocusState() {

--- a/components/visualizer/details-panel/Panel.vue
+++ b/components/visualizer/details-panel/Panel.vue
@@ -135,9 +135,9 @@ export default {
         return
       }
 
-      if (viewer.trackedEntity == entity) {
-        viewer.trackedEntity = null
-        viewer.selectedEntity = null
+      if (viewer.selectedEntity == entity) {
+        //viewer.trackedEntity = null
+        viewer.selectedEntity = false
         this.isTracked = false
         return
       }


### PR DESCRIPTION
This branch fixes the strange path distortion by changing viewer.selectedEntity on target press in order to trigger the camera positioning logic in the selectedEntityChanged listener.
I've made some additional changes to stop the camera flying away from the scenes of interest at the first opportunity. There are still issues (for example the flash of position change before the camera starts moving) but I think it's going in the right direction.