### PR TITLE
fix: #156 github action astria-graph error status

### DIFF
--- a/.github/workflows/astria-graph.yml
+++ b/.github/workflows/astria-graph.yml
@@ -12,6 +12,6 @@ jobs:
     
     steps:
     - name: Trigger our build webhook on Netlify
-      run: curl -s -X POST "${TOKEN}"
+      run: curl --silent --show-error --fail -X POST "${TOKEN}"
       env:
         TOKEN: ${{ secrets.AG_API_URL }}


### PR DESCRIPTION
this fix hopefully addresses the zero exit status of curl when it
returns a non 2XX response status code. it may not fully address this
issue but is hard to test without running on the github actions server

 Changes to be committed:
	modified:   .github/workflows/astria-graph.yml