### PR TITLE
Bug/visualizer design tweaks

### DIFF
--- a/assets/css/components/filter-results.scss
+++ b/assets/css/components/filter-results.scss
@@ -88,7 +88,19 @@
 
       &__navigation {
         float: none !important;
+        @extend %font-ui-text-base-oxygen;
         text-align: center;
+      }
+
+      &__navigation__page-info {
+        margin: 0 rem(24) 0 0;
+      }
+
+      /* stylelint-disable-next-line */
+      &__navigation__page-btn,
+      &__navigation__page-btn span {
+        @extend %font-ui-text-base-oxygen;
+        font-weight: normal;
       }
     }
   }

--- a/assets/css/components/form-input.scss
+++ b/assets/css/components/form-input.scss
@@ -172,13 +172,24 @@
 }
 
 .dropdown--simple {
+  .vs__selected {
+    white-space: nowrap;
+  }
+
   .vs__selected-options {
     flex-shrink: 1;
     justify-content: flex-end;
   }
 
   .vs__search {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
   }
 
   .vs__dropdown-menu {

--- a/assets/css/components/timeline.scss
+++ b/assets/css/components/timeline.scss
@@ -286,8 +286,15 @@
     flex: 0 0 auto;
   }
 
-  .vs__selected-options input {
-    display: none;
+  .vs__search {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
   }
 
   .vs__open-indicator {
@@ -296,6 +303,8 @@
   }
 
   .vs__dropdown-menu {
+    top: unset;
+    bottom: calc(100% + 1px);
     background: $color-slate-700;
     border: 0;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6909,6 +6909,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
       "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -11097,6 +11098,7 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
       "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -17448,6 +17450,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"


### PR DESCRIPTION
This fixes 3 weird bugs that at some point got introduced:

- The timeline dropdowns needed to go up instead of down to prevent a vertical scrollbar/overflow
- The filter results pagination typography was being overridden by the vue table plugin default styles
- The sort dropdown on the filter results was still breaking onto 2 lines sometimes.