### PR TITLE
Design tweaks on key events page

### DIFF
--- a/assets/css/pages/key-events.scss
+++ b/assets/css/pages/key-events.scss
@@ -36,7 +36,7 @@
 
   &__date {
     .form__label {
-      margin-bottom: rem(8);
+      margin-bottom: rem(4);
     }
 
     .sd-icon-calendar,
@@ -147,6 +147,16 @@
       color: $color-white-140;
     }
 
+    /* stylelint-disable-next-line */
+    th.sorting-desc button::before {
+      border-top: 5px solid $color-white-180;
+    }
+
+    /* stylelint-disable-next-line */
+    th.sorting-asc button::after {
+      border-bottom: 5px solid $color-white-180;
+    }
+
     th,
     td {
       &:first-of-type {
@@ -187,6 +197,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    padding: rem(24) 0;
     background: transparent;
     border: 0;
     border-top: 1px solid $color-white-115;
@@ -197,18 +208,39 @@
     }
 
     /* stylelint-disable-next-line */
+    .footer__row-count__label {
+      color: $color-white-150;
+      @extend %font-ui-text-lg-oxygen;
+    }
+
+    /* stylelint-disable-next-line */
     .footer__row-count__select {
       color: $color-white-170;
       background: $color-slate-400;
     }
 
+    .footer__row-count::after {
+      display: none;
+    }
+
     .footer__navigation {
+      @extend %font-ui-text-lg-oxygen;
       text-align: right;
+    }
+
+    /* stylelint-disable-next-line */
+    .footer__navigation__page-info {
+      margin-right: rem(24);
     }
 
     /* stylelint-disable-next-line */
     .footer__navigation__page-info__current-entry {
       background: $color-slate-400;
+    }
+
+    /* stylelint-disable-next-line */
+    .footer__navigation__page-btn {
+      font-weight: normal;
     }
   }
 }

--- a/pages/key-events.vue
+++ b/pages/key-events.vue
@@ -99,7 +99,11 @@
             mode: 'pages',
             perPage: serverParams.perPage,
             pageLabel: 'Page',
-            dropdownAllowAll: false
+            dropdownAllowAll: false,
+            infoFn: (params) =>
+              `Page ${params.currentPage.toLocaleString(
+                'en-US'
+              )} of ${params.totalPages.toLocaleString('en-US')}`
           }"
           :sort-options="{
             enabled: true,


### PR DESCRIPTION
This fixes a few small things on the Key Events page.
- Standardizes the spacing between the labels & inputs in the form at the top
- Matches the sort carat color with the mockups
- Formats the "Page X of Y" at the bottom so it will include commas when necessary