### PR TITLE
Reset query params on reset button

### DIFF
--- a/components/visualizer/PanelLeft.vue
+++ b/components/visualizer/PanelLeft.vue
@@ -114,6 +114,10 @@ export default {
       this.resetSatelliteState()
       this.resetFiltersState()
       this.getOrbits()
+
+      if (!process.server) {
+        history.replaceState({}, null, window.origin)
+      }
     },
     ...mapMutations({
       updateVisibleSatellites: 'satellites/updateVisibleSatellites',


### PR DESCRIPTION
This clears the query params when the user clicks on the reset button. This is useful in cases where a user might be viewing a page with focused satellites or a specified datetime that were included in the URL.