### PR TITLE
Show multiple countries in results list

### DIFF
--- a/assets/css/components/close-approaches.scss
+++ b/assets/css/components/close-approaches.scss
@@ -69,6 +69,8 @@
     .sat__actions {
       grid-row: 1 / 3;
       justify-content: flex-end;
+      align-self: center;
+      text-align: right;
     }
   }
 

--- a/assets/css/components/filter-results.scss
+++ b/assets/css/components/filter-results.scss
@@ -51,7 +51,7 @@
     }
 
     .vgt-table {
-      /* stylelint-disable max-nesting-depth, selector-max-compound-selectors */
+      /* stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type */
       tbody tr:nth-of-type(odd) {
         background: $color-slate-700;
       }
@@ -66,8 +66,9 @@
           padding-left: var(--panel-padding-side);
         }
 
+        // Vue table  overflows the container by default, offset that here to avoid a horizontal scroll.
         &:last-of-type {
-          padding-right: var(--panel-padding-side);
+          padding-right: calc(var(--panel-padding-side) - 12px);
         }
       }
 
@@ -77,6 +78,10 @@
 
       td {
         --cell-vertical-padding: #{rem(12)};
+      }
+
+      td.filter-results__country {
+        @extend %font-ui-text-base-oxygen;
       }
       /* stylelint-enable */
     }

--- a/assets/css/components/satellite-block.scss
+++ b/assets/css/components/satellite-block.scss
@@ -22,7 +22,7 @@
 
     &--status {
       display: grid;
-      grid-template-columns: max-content auto;
+      grid-template-columns: max-content 2fr max-content max-content;
       column-gap: var(--marker-gap, rem(16));
       row-gap: rem(2);
 

--- a/assets/css/pages/key-events.scss
+++ b/assets/css/pages/key-events.scss
@@ -106,6 +106,7 @@
   .sat__actions {
     gap: rem(8);
     justify-content: center;
+    align-items: baseline;
     margin: 0;
     padding: 0;
   }

--- a/components/visualizer/CloseApproachesList.vue
+++ b/components/visualizer/CloseApproachesList.vue
@@ -40,7 +40,7 @@
           </div>
           <div class="sat__id">{{ object.catalog_id }}</div>
           <div class="sat__country">
-            {{ object.countryOfLaunch[0].id }}
+            {{ object.countries }}
           </div>
           <div class="sat__actions">
             <Button
@@ -122,11 +122,13 @@ export default {
           const id = ids[i]
           const { Name, Status, countryOfLaunch } = this.satellites[id]
 
+          let countries = countryOfLaunch.map((d) => d.id).join(' / ')
+
           objects.push({
             catalog_id: id,
             Name,
             Status,
-            countryOfLaunch
+            countries
           })
         }
 

--- a/components/visualizer/FilterResults.vue
+++ b/components/visualizer/FilterResults.vue
@@ -134,6 +134,8 @@ export default {
         {
           label: 'CO.',
           field: 'country',
+          tdClass: 'filter-results__country',
+          width: '4em',
           sortFn(x, y) {
             return x[0].id < y[0].id ? -1 : 1
           }


### PR DESCRIPTION
Closes #171 by making sure that in all places where a 3 letter ISO code is shown for a satellite's country, it will show multiple countries if a satellite is associated with more than 1 country. Also does a few design tweaks to fix alignments.

<img width="339" alt="Screen Shot 2021-07-13 at 5 03 46 PM" src="https://user-images.githubusercontent.com/1896496/125524746-97ed3005-6fc7-4eed-975b-8adb118e6307.png">
