### PR TITLE
Show disclaimer on focus list of no orbits are available

### DIFF
--- a/assets/css/components/satellite-block.scss
+++ b/assets/css/components/satellite-block.scss
@@ -47,6 +47,10 @@
         grid-column: 2;
         grid-row: 2;
       }
+
+      .sat__disclaimer {
+        grid-column: 2;
+      }
     }
   }
 

--- a/assets/css/components/satellite-block.scss
+++ b/assets/css/components/satellite-block.scss
@@ -50,6 +50,10 @@
 
       .sat__disclaimer {
         grid-column: 2;
+        margin-top: rem(12);
+        color: $color-white-160;
+        @extend %font-ui-text-xsm-oxygen;
+        letter-spacing: 0.025em;
       }
     }
   }

--- a/components/visualizer/FocusList.vue
+++ b/components/visualizer/FocusList.vue
@@ -52,6 +52,12 @@
           {{ satellites[item].Name }}
         </div>
         <div class="sat__id">{{ satellites[item].catalog_id }}</div>
+        <div
+          v-if="!orbits[item] || !orbits[item].orbits"
+          class="sat__disclaimer"
+        >
+          *This object is not yet in orbit
+        </div>
         <div class="sat__actions">
           <Button
             v-if="!isEditable"
@@ -111,6 +117,9 @@ export default {
     satellites() {
       return this.$store.state.satellites.satellites
     },
+    orbits() {
+      return this.$store.state.satellites.orbits
+    },
     numSelectedItems() {
       return this.selectedItems.length
     },
@@ -129,13 +138,11 @@ export default {
       this.objectLabels.classList.toggle('is-hidden', val)
     },
     focusedItems: function(val, oldVal) {
-      /*if (this.isOpen) {*/
       const visibleSatellites =
         this.focusedSatellites.size > 0
           ? [...this.focusedSatellites]
           : Object.keys(this.$store.state.satellites.satellites)
       this.updateVisibleSatellites(visibleSatellites)
-      /*}*/
     },
     '$route.query.satids': 'handleQueryString'
   },

--- a/services/time-events.js
+++ b/services/time-events.js
@@ -26,6 +26,10 @@ class TimeEvents {
     }
   }
 
+  getDate() {
+    return this.time.getDate()
+  }
+
   addListener(event, func) {
     this.listeners[event]
       ? this.listeners[event].push(func)

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -264,6 +264,10 @@ export const actions = {
         return
       }
 
+      if (typeof orbits === 'string') {
+        orbits = JSON.parse(orbits)
+      }
+
       // Todo: Modify active satellites here to trigger watch in CesiumViewer
 
       console.log('Get updated orbits.')


### PR DESCRIPTION
This exposes the orbit details to the Focus List component. If no orbits matching the satellite ID are there, or the list is empty (not sure if the API would ever supply an empty set, but in case it does) then the disclaimer is shown.