### PR TITLE
Fix details pane crash when no orbital data

### DIFF
--- a/components/visualizer/details-panel/Details.vue
+++ b/components/visualizer/details-panel/Details.vue
@@ -51,9 +51,9 @@
         </dd>
       </div>
     </dl>
+    <hr />
+    <h3>Orbit</h3>
     <div v-if="hasOrbit">
-      <hr />
-      <h3>Orbit</h3>
       <p class="details-panel__small-desc">Last updated on {{ orbitSource }}</p>
       <dl class="details__orbit">
         <div v-for="item in info.orbit" :key="item.value">
@@ -73,6 +73,9 @@
         </div>
       </dl>
     </div>
+    <p v-else class="details-panel__small-desc">
+      This object is not yet in orbit.
+    </p>
     <!-- <hr />
     <h3>ITU Filings</h3> -->
     <template v-if="satellite.acf.comments">
@@ -207,18 +210,19 @@ export default {
   },
   computed: {
     hasOrbit() {
-      if (!this.satelliteAllOrbits || this.satelliteAllOrbits.length === -1) {
-        return
+      if (!this.satelliteAllOrbits || !this.satelliteAllOrbits.length) {
+        return false
       }
 
       return true
     },
     satelliteAllOrbits() {
+      if (!this.orbits[this.id]) {
+        return []
+      }
       return this.orbits[this.id].orbits
     },
     orbitalElements() {
-      // TODO: Need to get the right orbit for the current timeline
-      // watch for date boundary change and set index accordingly
       const index = this.satelliteAllOrbits[this.elementIndex]
         ? this.elementIndex
         : 0

--- a/components/visualizer/details-panel/Panel.vue
+++ b/components/visualizer/details-panel/Panel.vue
@@ -11,6 +11,7 @@
           aria-label="Zoom Into Sattelite"
           :class="{ 'btn--is-focused': isSatelliteTracked }"
           :on-click="trackObject"
+          :disabled="!hasOrbit"
         >
           <Icon id="target" name="target" focusable="false" />
         </Button>
@@ -78,8 +79,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-import { mapMutations } from 'vuex'
+import { mapState, mapMutations } from 'vuex'
 import Button from '~/components/global/Button'
 import Details from '~/components/visualizer/details-panel/Details.vue'
 import Events from '~/components/visualizer/details-panel/Events.vue'
@@ -131,8 +131,22 @@ export default {
     isSatelliteTracked() {
       return this.isTracked
     },
+    hasOrbit() {
+      if (!this.satelliteAllOrbits || !this.satelliteAllOrbits.length) {
+        return false
+      }
+
+      return true
+    },
+    satelliteAllOrbits() {
+      if (!this.orbits[this.id]) {
+        return []
+      }
+      return this.orbits[this.id].orbits
+    },
     ...mapState({
-      focusedSatellites: (state) => state.satellites.focusedSatellites
+      focusedSatellites: (state) => state.satellites.focusedSatellites,
+      orbits: (state) => state.satellites.orbits
     })
   },
   watch: {


### PR DESCRIPTION
Close #44 
Also resolves some items in #126 

This PR does a few related tasks:
1. In a situation where a user is viewing the details pane of a satellite that does not have orbital information for the given timeframe, it hides the orbital information and instead shows the message "This object is not yet in orbit." that is used elsewhere on the site.
2. In the above situation, the button to "focus" on the satellite is disabled. The button to "pin" the satellite is still active, because we do want someone to be able to add the satellite to their focus list.
  *  There is a weird side effect that can happen here: "pinning" a satellite adds it to the focus list, which can cause the visualizer to update to only show "focused" satellites. In this case, the visual is empty because there's no orbital information available for the pinned satellite (if it's the only one pinned). The disclaimer is included in both the details pane and the focus list though, so I think this is an acceptable trade-off. Just wanted to flag as to why this button was not also disabled.
3. This also fixes a bug where if the satellite didn't have any orbital information the whole site would crash because there weren't proper conditionals in place to handle that use case.

## To Test
1. When all the satellite's have loaded, find a satellite that is launched after 2011.
2. With the details pane of that satellite open, change the time of the timeline to sometimes in 2010.
3. The visual will update with new orbital data and you should see the above changes.
