### PR TITLE
Remove unused ACF fields

### DIFF
--- a/components/visualizer/details-panel/Details.vue
+++ b/components/visualizer/details-panel/Details.vue
@@ -78,11 +78,11 @@
     </p>
     <!-- <hr />
     <h3>ITU Filings</h3> -->
-    <template v-if="satellite.acf.comments">
+    <template v-if="satellite.comments">
       <hr />
       <h3>Comments</h3>
       <ul
-        v-for="comment in satellite.acf.comments"
+        v-for="comment in satellite.comments"
         :key="comment.date"
         class="details-panel__comments"
         role="list"

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -183,8 +183,6 @@ export const actions = {
 
       /**
        * Todo:
-       * Show manual overrides in ACF fields
-       * Match country with spreadsheet
        * Dynamically load in status & country spreadsheets
        */
 
@@ -196,6 +194,7 @@ export const actions = {
           post_id: id,
           catalog_id: acf.catalog_id,
           ...ag_meta,
+          alternate_name: acf.name,
           comments: acf.comments
         }))
         .forEach((sat) => {

--- a/store/satellites.js
+++ b/store/satellites.js
@@ -195,11 +195,11 @@ export const actions = {
         .map(({ id, ag_meta, acf }) => ({
           post_id: id,
           catalog_id: acf.catalog_id,
-          acf,
-          ...ag_meta
+          ...ag_meta,
+          comments: acf.comments
         }))
         .forEach((sat) => {
-          let status_type = Types[sat.acf.catalog_id]?.type || 'TBA'
+          let status_type = Types[sat.catalog_id]?.type || 'TBA'
 
           if (status_type == 'payload') {
             if (sat.Status == 'active') {
@@ -229,7 +229,7 @@ export const actions = {
             })
           })
 
-          items[sat.acf.catalog_id] = {
+          items[sat.catalog_id] = {
             ...sat,
             countryOfLaunch,
             countryOfLaunchIds,
@@ -237,7 +237,7 @@ export const actions = {
           }
 
           // By default all items are visible!
-          visibleItems.push(sat.acf.catalog_id)
+          visibleItems.push(sat.catalog_id)
         })
 
       countriesOfLaunch = [...countriesOfLaunch].sort((a, b) =>


### PR DESCRIPTION
Closes #121 

The front end companion to [Override AG Data](https://github.com/CSIS-iLab/satellite-dashboard-backend/pull/34). This updates the satellites object in the store to only keep the ACF fields that we explicitly need - the catalog_id and comments fields.

There are a few remaining references to `acf.catalog_id`. These occur in reference to a post's related satellites ACF, so couldn't be totally removed as they're used to match up the related satellite with its corresponding entry in the satellites store.