### PR TITLE
Added satellite block variation

### DIFF
--- a/assets/css/components/satellite-block.scss
+++ b/assets/css/components/satellite-block.scss
@@ -26,6 +26,15 @@
       column-gap: var(--marker-gap, rem(16));
       row-gap: rem(2);
 
+      &-simple {
+        grid-template-columns: max-content auto;
+
+        /* stylelint-disable-next-line */
+        .filter-results & {
+          grid-template-columns: max-content minmax(auto, 128px);
+        }
+      }
+
       &::before {
         content: '';
         display: block;

--- a/components/visualizer/FilterResults.vue
+++ b/components/visualizer/FilterResults.vue
@@ -41,7 +41,7 @@
         <template slot="table-column" slot-scope="props">
           <div
             v-if="props.column.field == 'Name'"
-            class="sat__basic sat__basic--status"
+            class="sat__basic sat__basic--status sat__basic--status-simple"
           >
             <div class="sat__name">
               {{ props.column.label }}
@@ -54,7 +54,7 @@
         <template slot="table-row" slot-scope="props">
           <div v-if="props.column.field == 'Name'">
             <div
-              class="sat__basic sat__basic--status"
+              class="sat__basic sat__basic--status sat__basic--status-simple"
               :data-status="props.row.Status"
             >
               <div class="sat__name">

--- a/components/visualizer/details-panel/Details.vue
+++ b/components/visualizer/details-panel/Details.vue
@@ -18,7 +18,7 @@
         <dt class="visually-hidden">Status</dt>
         <dd>
           <div
-            class="sat__basic sat__basic--status"
+            class="sat__basic sat__basic--status sat__basic--status-simple"
             :data-status="satellite.Status"
           >
             {{ statusTypes[satellite.Status].label }}

--- a/pages/key-events.vue
+++ b/pages/key-events.vue
@@ -141,7 +141,7 @@
               "
             >
               <div
-                class="sat__basic sat__basic--status"
+                class="sat__basic sat__basic--status sat__basic--status-simple"
                 :data-status="
                   satellites[props.formattedRow[props.column.field]].Status
                 "


### PR DESCRIPTION
Closes #219 

Makes a new variation on the `.sat__basic--status` block with a simpler grid structure for just the status icon and the satellite name. I applied those in a couple of other places where those were the only items listed.

I also explicitly set the max width on the filter results version, which fixes the alignment issues as far as I can tell. There's likely to still be some screen sizes where things get a little bit unaligned because of how Vue Table works and calculates the widths of the table columns, but this is the best we can do with the existing structure.