### PR TITLE
Tooltip should follow mouse position

### DIFF
--- a/components/global/GlossaryTooltip.vue
+++ b/components/global/GlossaryTooltip.vue
@@ -8,6 +8,7 @@
         interactive-border="4"
         distance="12"
         arrow
+        follow-cursor="true"
       >
         <template v-slot:trigger>
           <button

--- a/components/global/GlossaryTooltip.vue
+++ b/components/global/GlossaryTooltip.vue
@@ -8,7 +8,7 @@
         interactive-border="4"
         distance="12"
         arrow
-        follow-cursor="true"
+        :follow-cursor="true"
       >
         <template v-slot:trigger>
           <button


### PR DESCRIPTION
Closes #230 

I set the [`follow-cursor` attribute](https://kabbouchi.github.io/vue-tippy/4.0/demo.html#follow-cursor) for the Tippy tooltips so it should more closely follow the mouse.