### PR TITLE
Set SimStart to query date if it's null

### DIFF
--- a/components/visualizer/CesiumViewer.vue
+++ b/components/visualizer/CesiumViewer.vue
@@ -182,6 +182,9 @@ export default {
       if (!viewer || !Cesium) {
         return
       }
+      this.SimStart =
+        this.SimStart ||
+        Cesium.JulianDate.fromDate(new Date(this.$route.query.date))
       if (this.$route.query.time) {
         let seconds = parseInt(this.$route.query.time)
         if (isNaN(seconds)) {


### PR DESCRIPTION
Certain cases in which SimStart would be null, and passing null instead of a JulianDate to the Cesium AddSeconds method caused Cesium to bail out with that error. Makes sense (I think) to use the date parameter passed in via the query string.

This of course won't fully work if (as at present) there is no corresponding orbit data for the time in question. My suspicion is that the close approach data will run out until the issue with the Astria data source is resolved.